### PR TITLE
Remove Adam Miller (CommComm Member)

### DIFF
--- a/templates/observers_commcomm
+++ b/templates/observers_commcomm
@@ -3,7 +3,6 @@
 * @rykerrumsey (Ryker Rumsey - observer)
 * @baez (Behzad Karim - observer)
 * @BinarySo1o (Therese Stirling - observer)
-* @amiller-gh (Adam Miller - observer)
 * @yosuke-furukawa (Yosuke Furukawa - observer)
 * @Maurice-Hayward (Maurice Hayward - observer)
 * @mikehostetler (Mike Hostetler - observer)


### PR DESCRIPTION
Adam's become a CommComm member and no longer needs to be included in the observers list because he's become a member. Ref: https://github.com/nodejs/community-committee/pull/265