### PR TITLE
Add note about where templates should go

### DIFF
--- a/TEMPLATES_DOCUMENTATION.md
+++ b/TEMPLATES_DOCUMENTATION.md
@@ -1,4 +1,4 @@
-This document contains empty versions of each template needed to successfully create meeting artifacts for a Committee, Working Group, Initiative, or Team.
+This document contains empty versions of each template needed to successfully create meeting artifacts for a Committee, Working Group, Initiative, or Team. These documents need to go in the [/templates](./templates) directory in this repository.
 
 There are only four variables in the documents that _need_ to be changed:
 


### PR DESCRIPTION
Updates the templates documentation with a quick note about *where* things should go. Stems from a discussion with a CommComm observer who wasn't sure about this, and assumed they needed to go inside the respective repo.