### PR TITLE
Attendance note for CommComm & removing Tiriel

### DIFF
--- a/templates/minutes_base_commcomm
+++ b/templates/minutes_base_commcomm
@@ -10,6 +10,7 @@
 
 $INVITED$
 $OBSERVERS$
+*Members and Observers: In order to facilitate attendance tracking, don't hesitate do add yourselves to the minutes doc*
 
 ## Agenda
 

--- a/templates/observers_commcomm
+++ b/templates/observers_commcomm
@@ -1,4 +1,3 @@
-* @Tiriel (Benjamin Zaslavsky - observer)
 * @DiegoZoracKy (Diego ZoracKy - observer)
 * @ZibbyKeaton (Zibby Keaton - observer)
 * @Bamieh (Ahmad Bamieh - observer)


### PR DESCRIPTION
Remove Tiriel from CommComm Observers, add attendance note to CommCommMinutes